### PR TITLE
fix #88: fix validation with autofill

### DIFF
--- a/src/utils/ValidationUtil.tsx
+++ b/src/utils/ValidationUtil.tsx
@@ -178,7 +178,11 @@ export default class ValidationUtil {
                                         this.getValidationErrorMsg(formField.validation, "requiredDetail") ||
                                         MSGS.ERROR_MSG.REQUIRED;
                                     hasErrors = true;
+                                    return;
                                 }
+                            } else {
+                                formField.error.hasError = false;
+                                formField.error.errorMsg = "";
                             }
 
                             // for pattern validation - string only
@@ -193,6 +197,10 @@ export default class ValidationUtil {
                                             this.getValidationErrorMsg(formField.validation, "patternDetail") ||
                                             MSGS.ERROR_MSG.PATTERN;
                                         hasErrors = true;
+                                        return;
+                                    } else {
+                                        formField.error.hasError = false;
+                                        formField.error.errorMsg = "";
                                     }
                                 }
                             }


### PR DESCRIPTION
Issues to reproduce:
- open a form with more than two text, required fields (otherwise use address fields)
- submit the form, it will show errors in two fields as "is required"
- try to enter value in both fields at once using autofill and click on submit
- error from one field will be gone, but other field still shows error